### PR TITLE
Make declarative_enum_dispatch work with no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 /*!
 # Declarative generation of enum dispatch
 


### PR DESCRIPTION
I'm trying to use this with a gba project using `agb`, since it's much nicer than the enum dispatch crate which we've used for previous games (the implementation of that depends on some internal implementation details of the rust compiler which is why it doesn't work very well with rust analyzer or other IDE integrations).

However, for that I need no_std. So I've added the no_std directive here which will let this crate be used in embedded systems where this sort of thing is really useful.